### PR TITLE
fix: change the root directory to search plugins to 'Plugins' folder

### DIFF
--- a/OC.Assistant/Plugins/PluginRegister.cs
+++ b/OC.Assistant/Plugins/PluginRegister.cs
@@ -17,23 +17,22 @@ internal static class PluginRegister
     public static List<Type> Types { get; } = [];
 
     /// <summary>
+    /// The full path of the plugins search directory. 
+    /// </summary>
+    public static string SearchPath { get; } = Path.GetFullPath(@".\Plugins"); 
+
+    /// <summary>
     /// Tries to load available plugins depending on the current environment (debug or executable). 
     /// </summary>
     public static void Initialize()
     {
-        try
+        if (Directory.Exists(SearchPath))
         {
-            foreach (var pluginFile in Directory
-                         .GetFiles(Environment.CurrentDirectory, "*.plugin", SearchOption.AllDirectories))
-            {
-                Load(pluginFile);
-            }
+            Directory
+                .GetFiles(SearchPath, "*.plugin", SearchOption.AllDirectories)
+                .ToList().ForEach(Load);
         }
-        catch (Exception e)
-        {
-            Logger.LogError(typeof(PluginRegister), e.Message);
-        }
-        
+            
 #if DEBUG
         /*
          Search outside the solution environment when debugging
@@ -42,11 +41,9 @@ internal static class PluginRegister
          */
         try
         {
-            foreach (var pluginFile in Directory
-                         .GetFiles(@"..\..\..\..\..\", "*.plugin", SearchOption.AllDirectories))
-            {
-                Load(pluginFile);
-            }
+            Directory
+                .GetFiles(@"..\..\..\..\..\", "*.plugin", SearchOption.AllDirectories)
+                .ToList().ForEach(Load);
         }
         catch (Exception e)
         {

--- a/OC.Assistant/Plugins/XmlFile.cs
+++ b/OC.Assistant/Plugins/XmlFile.cs
@@ -60,7 +60,8 @@ internal static class XmlFile
             var pluginType = PluginRegister.GetTypeByName(type);
             if (pluginType is null)
             {
-                Logger.LogWarning(typeof(XmlFile), $"Plugin for type '{type}' not found");
+                Logger.LogWarning(typeof(XmlFile), 
+                    $"Plugin for type '{type}' not found in directory {PluginRegister.SearchPath}");
                 continue;
             }
             if (name is null || parameter is null) continue;

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ Plugin use cases:
   - Modbus Server and Client communication
 
 ### Installation
-1. Move the plugin folder into the directory of the `OC.Assistant.exe`.
-2. Start the `OC.Assistant.exe` application.
-3. The Assistant will automatically search through all subdirectories for `*.plugin` files and load any compatible plugin assemblies.
-4. Once loaded, the plugin will be available for use within the Assistant.
+1. Create a folder named `Plugins` in the directory of the `OC.Assistant.exe`.
+2. Move the plugin folder into the `Plugins` folder.
+3. Start the `OC.Assistant.exe` application.
+4. The Assistant will search through all subdirectories for `*.plugin` files and load any compatible plugin assemblies.
+5. Once loaded, the plugin will be available for use within the Assistant.
 
 ### Usage
 1. Create a new instance of a plugin using the `+` button


### PR DESCRIPTION
To prevent excessive recursive search, the Assistant will only search in a folder named 'Plugins' for available plugins.